### PR TITLE
adding more information about offline doc and search

### DIFF
--- a/en/intro.html
+++ b/en/intro.html
@@ -159,6 +159,15 @@ class: middle, left
 ---
 class: middle, left
 
+## Offline Documentation
+
+* Several books are installed, `rustup doc -h` to list them
+* Search: look for search box or 🔍 symbol at top of pages
+* Material and search are usable offline
+
+---
+class: middle, left
+
 ## API Documentation
 
 https://doc.rust-lang.org/

--- a/es/intro.html
+++ b/es/intro.html
@@ -159,6 +159,15 @@ class: middle, left
 ---
 class: middle, left
 
+## Documentación sin conexión
+
+* Varios manuales estan incluidos, `rustup doc -h` para listarlos
+* Busqueda: al inicio de cada pagina hay un campo de busqueda o este simbolo 🔍
+* Todo el material y la busqueda estan disponibles sin conexion
+
+---
+class: middle, left
+
 ## Documentación del API
 
 https://doc.rust-lang.org/


### PR DESCRIPTION
I use `rustup doc --std` a lot, and often offline, when on a train or car ride, and somehow had completely missed that search is available. It was recently pointed out to me, and I'm very impressed by the quality of the search functionality, this is really useful.

Similarly, I've used the offline book a few times, but mainly the standard library, and again not really clicked on the fact that the Rust Reference and other valuable are available offline too.

I think those two things need to be advertised more.