### PR TITLE
How to display path for local doc

### DIFF
--- a/en/intro.html
+++ b/en/intro.html
@@ -169,6 +169,8 @@ Click on "Standard Library API Reference"
 or
 `rustup doc --std`
 
+`rustup doc --std --path` to show local path
+
 ---
 class: middle, left
 

--- a/es/intro.html
+++ b/es/intro.html
@@ -169,6 +169,8 @@ Click en "Standard Library API Reference"
 o
 `rustup doc --std`
 
+`rustup doc --std --path` para ver la ruta local
+
 ---
 class: middle, left
 


### PR DESCRIPTION
Especially useful when users install rustup in WSL on Windows 10, there is not browser available in WSL, one from the Windows side needs to be used. It is very helpful to be able to quickly identify where on the filesystem the doc is.

Thanks again to @kidpollo for helping with the translation.