### PR TITLE
Removed `_u32` literal syntax in favor of `: u32` explicit type declaration

### DIFF
--- a/en/intro.html
+++ b/en/intro.html
@@ -312,7 +312,7 @@ class: middle, left
 
 ```rust
 fn main() {
-    let height = 167u32;
+    let height: u32 = 167;
     if height < 150 {
         println!("You're too small to go on the rollercoaster.");
     } else if height < 200 {
@@ -337,7 +337,7 @@ Kinda like a switch. But better.
 
 ```rust
 fn main() {
-    let height = 167u32;
+    let height: u32 = 167;
     match height {
         0..=150 => println!("You're too small to go on the rollercoaster."),
         150..=200 => println!("You may go on the rollercoaster!"),

--- a/es/intro.html
+++ b/es/intro.html
@@ -311,7 +311,7 @@ class: middle, left
 
 ```rust
 fn main() {
-    let height = 167u32;
+    let height: u32 = 167;
     if height < 150 {
         println!("Eres demasiado pequeño para ir en la montaña rusa.");
     } else if height < 200 {
@@ -336,7 +336,7 @@ Como un `switch`. Pero mejor
 
 ```rust
 fn main() {
-    let height = 167u32;
+    let height: u32 = 167;
     match height {
         0..=150 => println!("Eres demasiado pequeño para ir en la montaña rusa."),
         150..=200 => println!("¡Puedes ir en la montaña rusa!"),


### PR DESCRIPTION
Today's Berlin RustBridge workshop revealed confusion around the use of  the `…_u32` literal syntax, which could easily be resolved by switching to simply `: u32`.