### PR TITLE
Removed blocks around single-expression match cases

### DIFF
--- a/en/intro.html
+++ b/en/intro.html
@@ -341,9 +341,7 @@ fn main() {
     match height {
         0..=150 => println!("You're too small to go on the rollercoaster."),
         150..=200 => println!("You may go on the rollercoaster!"),
-        _ => {
-            println!("You're too tall to go on the rollercoaster.");
-        },
+        _ => println!("You're too tall to go on the rollercoaster."),
     }
 }
 ```
@@ -539,9 +537,7 @@ match game {
     GameType::SinglePlayer => println!("How about solitaire?"),
     GameType::MultiPlayer(2) => println!("How about checkers?"),
     GameType::MultiPlayer(4) => println!("How about bridge?"),
-    GameType::MultiPlayer(num) => {
-        println!("How about {}-player tag?", num)
-    },
+    GameType::MultiPlayer(num) => println!("How about {}-player tag?", num),
 }
 ```
 
@@ -690,12 +686,8 @@ class: middle, left
 let b: Option<&str> = Some("Carol");
 
 match b {
-    Some(name) => {
-        println!("Other name is {} bytes long", name.len())
-    },
-    None => {
-        println!("No name!")
-    }
+    Some(name) => println!("Other name is {} bytes long", name.len()),
+    None => println!("No name!"),
 }
 ```
 

--- a/es/intro.html
+++ b/es/intro.html
@@ -340,9 +340,7 @@ fn main() {
     match height {
         0..=150 => println!("Eres demasiado pequeño para ir en la montaña rusa."),
         150..=200 => println!("¡Puedes ir en la montaña rusa!"),
-        _ => {
-            println!("Eres demasiado alto para ir en la montaña rusa.");
-        },
+        _ => println!("Eres demasiado alto para ir en la montaña rusa."),
     }
 }
 ```
@@ -539,9 +537,7 @@ match game {
     GameType::SinglePlayer => println!("¿Qué tal un solitario?"),
     GameType::MultiPlayer(2) => println!("¿Qué tal un ajedrez?"),
     GameType::MultiPlayer(4) => println!("¿Qué tal un bridge?"),
-    GameType::MultiPlayer(num) => {
-        println!("¿Qué tal un juego para {} jugadores?", num)
-    },
+    GameType::MultiPlayer(num) => println!("¿Qué tal un juego para {} jugadores?", num),
 }
 ```
 
@@ -690,12 +686,8 @@ class: middle, left
 let b: Option<&str> = Some("Carol");
 
 match b {
-    Some(name) => {
-        println!("El otro nombre tiene {} bytes de longitud", name.len())
-    },
-    None => {
-        println!("¡Sin nombre!")
-    }
+    Some(name) => println!("El otro nombre tiene {} bytes de longitud", name.len()),
+    None => println!("¡Sin nombre!"),
 }
 ```
 


### PR DESCRIPTION
At today's RustBridge workshow there was confusion around the inconsistent use of `=> … ,` vs. `=> { …; },`.

Given that the snippets use single expressions for each case it's clearer to use the same syntax for all.

This also avoids having to explain why `=> …;,` is invalid, while `=> { …; },` is not.