### PR TITLE
Make if/else example match match example

### DIFF
--- a/en/intro.html
+++ b/en/intro.html
@@ -315,7 +315,7 @@ fn main() {
     let height: u32 = 167;
     if height < 150 {
         println!("You're too small to go on the rollercoaster.");
-    } else if height < 200 {
+    } else if height > 150 && height <= 200 {
         println!("You may go on the rollercoaster!");
     } else {
         println!("You're too tall to go on the rollercoaster.");


### PR DESCRIPTION
The original if/if else branches didn't really make sense. I noticed during the intro this morning.